### PR TITLE
Fix first startup issues

### DIFF
--- a/komorebi-tray.ahk
+++ b/komorebi-tray.ahk
@@ -56,6 +56,10 @@ Startup() {
         "https://raw.githubusercontent.com/LGUG2Z/komorebi/master/docs/komorebi.example.json",
         Komorebi.configJson
       )
+      jsonConfig := FileRead(Komorebi.configJson)
+      jsonConfig := StrReplace(jsonConfig, "$Env:USERPROFILE", "$Env:KOMOREBI_CONFIG_HOME")
+      FileDelete(Komorebi.configJson)
+      FileAppend(jsonConfig, Komorebi.configJson)
     }
   }
 

--- a/komorebi-tray.ahk
+++ b/komorebi-tray.ahk
@@ -40,6 +40,7 @@ Startup() {
   }
 
   if ( not FileExist(Komorebi.configJson)) {
+    DirCreate(Komorebi.CONFIG_HOME)
     if (FileExist(Komorebi.userProfileJson)) {
       MsgBox(
         "Detected: " Komorebi.userProfileJson "`n`n" .

--- a/komorebi-tray.ahk
+++ b/komorebi-tray.ahk
@@ -49,8 +49,8 @@ Startup() {
       FileMove(Komorebi.userProfileJson, Komorebi.configJson)
     } else {
       MsgBox(
-        "komorebi.json not detected.`n`n" .
-        "Downloading defaults to: " Komorebi.configJson
+        "komorebi.json and applications.json not detected.`n`n" .
+        "Downloading defaults to: " Komorebi.CONFIG_HOME
       )
       Komorebi.newConfigFiles()
     }
@@ -79,6 +79,9 @@ Startup() {
     Settings.save(profiles[1], "active", "profiles")
   }
 
+  KomorebiTray.create(profiles)
+  KomorebiProfile.enable(KomorebiProfile.active)
+
   if ( not Komorebi.isRunning) {
     try {
       RunWait(("komorebic.exe"), , "Hide")
@@ -95,8 +98,6 @@ Startup() {
   }
 
   KomorebiEvents.start()
-  KomorebiTray.create(profiles)
-  KomorebiProfile.enable(KomorebiProfile.active)
 }
 
 TraySetIcon("images/ico/app.ico")

--- a/komorebi-tray.ahk
+++ b/komorebi-tray.ahk
@@ -52,14 +52,7 @@ Startup() {
         "komorebi.json not detected.`n`n" .
         "Downloading defaults to: " Komorebi.configJson
       )
-      Download(
-        "https://raw.githubusercontent.com/LGUG2Z/komorebi/master/docs/komorebi.example.json",
-        Komorebi.configJson
-      )
-      jsonConfig := FileRead(Komorebi.configJson)
-      jsonConfig := StrReplace(jsonConfig, "$Env:USERPROFILE", "$Env:KOMOREBI_CONFIG_HOME")
-      FileDelete(Komorebi.configJson)
-      FileAppend(jsonConfig, Komorebi.configJson)
+      Komorebi.newConfigFiles()
     }
   }
 

--- a/lib/Komorebi.ahk
+++ b/lib/Komorebi.ahk
@@ -10,14 +10,18 @@ Class Komorebi
   ; Userprofile komorebi.ahk file path.
   static userProfileAhk => this.USERPROFILE "\komorebi.ahk"
   ; Userprofile applications.yaml file path.
-  static userProfileYaml => this.USERPROFILE "\applications.yaml"
+  static userProfileAppYaml => this.USERPROFILE "\applications.yaml"
+  ; Userprofile applications.json file path.
+  static userProfileAppJson => this.USERPROFILE "\applications.json"
 
   ; Default komorebi.json file path.
   static configJson => this.CONFIG_HOME "\komorebi.json"
   ; Default komorebi.ahk file path.
   static configAhk => this.CONFIG_HOME "\komorebi.ahk"
   ; Default applications.yaml file path.
-  static configYaml => this.CONFIG_HOME "\applications.yaml"
+  static configAppYaml => this.CONFIG_HOME "\applications.yaml"
+  ; Default applications.yaml file path.
+  static configAppJson => this.CONFIG_HOME "\applications.json"
 
   ; Return true if komorebi.exe is running in background
   static isRunning => ProcessExist("komorebi.exe") ? true : false
@@ -69,5 +73,19 @@ Class Komorebi
   ; Unsubscribe komorebi from a named pipe.
   static unsubscribe(pipe_name) {
     this.command(Format("unsubscribe-pipe {}", pipe_name))
+  }
+
+  ; Fetch and create needed configuration files
+  static newConfigFiles() {
+    ; Download latest komorebi.json example
+    Download(
+      "https://raw.githubusercontent.com/LGUG2Z/komorebi/master/docs/komorebi.example.json",
+      this.configJson
+    )
+    ; Use `KOMOREBI_CONFIG_HOME` as root for applications.json
+    jsonConfig := FileRead(this.configJson)
+    jsonConfig := StrReplace(jsonConfig, "$Env:USERPROFILE", "$Env:KOMOREBI_CONFIG_HOME")
+    FileDelete(this.configJson)
+    FileAppend(jsonConfig, this.configJson)
   }
 }

--- a/lib/Komorebi.ahk
+++ b/lib/Komorebi.ahk
@@ -75,6 +75,11 @@ Class Komorebi
     this.command(Format("unsubscribe-pipe {}", pipe_name))
   }
 
+  ; Fetch the latest version of applications.json.
+  static getConfigAppJson() {
+    this.command("fetch-app-specific-configuration")
+  }
+
   ; Fetch and create needed configuration files
   static newConfigFiles() {
     ; Download latest komorebi.json example
@@ -87,5 +92,7 @@ Class Komorebi
     jsonConfig := StrReplace(jsonConfig, "$Env:USERPROFILE", "$Env:KOMOREBI_CONFIG_HOME")
     FileDelete(this.configJson)
     FileAppend(jsonConfig, this.configJson)
+    ; Fetch the latest version of applications.json
+    this.getConfigAppJson()
   }
 }

--- a/lib/KomorebiProfile.ahk
+++ b/lib/KomorebiProfile.ahk
@@ -31,7 +31,9 @@ Class KomorebiProfile
   static enable(profile) {
     Settings.save(profile, "active", "profiles")
     ; Create a hard link from /profiles to config home.
-    FileDelete(Komorebi.configAhk)
+    if (FileExist(Komorebi.configAhk)) {
+      FileDelete(Komorebi.configAhk)
+    }
     success := DllCall(
       "CreateHardLink",
       "Str", Komorebi.configAhk, ; Name of the new file (hard link).


### PR DESCRIPTION
On the first start, komorebi-tray now:

- [Creates KOMOREBI_CONFIG_HOME directory if it does not exist](https://github.com/starise/komorebi-tray/commit/10cff2afb00c31826d001f93035e9da28578d5a1)
- [Uses KOMOREBI_CONFIG_HOME as root for applications.json](https://github.com/starise/komorebi-tray/commit/57bce296e19796ef197030a1262cc41f1559a06f)
- [Checks `komorebi.ahk` existence (for deletion) before switching profiles](https://github.com/starise/komorebi-tray/commit/9c20f8911d994c2f9a5575d944f670977732f0f1)
- [Ensures that a profile is enabled before komorebi starts](https://github.com/starise/komorebi-tray/commit/109a58a7bb5091a2a6d21b599b45c7995e98c2b6)

A related small *feature* has been implemented, komoreby-tray now: 
- [Downloads the latest applications.json on first start](https://github.com/starise/komorebi-tray/commit/1a499b5f5f126310d30725e413de9dfa6ef0df45)

These changes should address all the major issues and Resolve #5